### PR TITLE
PEITHO 26.02.2 from beta

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: PEITHO
 Type: Package
 Title: Workflow Management and Reproducible Analysis in R
-Version: 26.02.1
+Version: 26.02.2
 Date: 2026-02-10
 Authors@R: c(person("Antonia", "Runge", email = "antonia.runge@inwt-statistics.de", role = c("aut", "cre")))
 Description: PEITHO provides a flexible workflow management system for reproducible data analysis pipelines in R. Users can define, execute, export, and import multi-step workflows using configuration files or interactive tools. The package supports web text fetching, data processing, and integration with custom R scripts. Workflows and their results can be shared as zip bundles, enabling collaboration and reuse. Designed for both interactive and automated use, PEITHO helps streamline complex analysis tasks and ensures reproducibility.

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ RUN installPackage
 # Expose ports
 EXPOSE 3838
 
-CMD ["Rscript", "-e", "library(shiny); PEITHO::startApplication(3838, host = '0.0.0.0')"]
+CMD ["Rscript", "-e", "library(shiny); PEITHO::startApplication(3838)"]

--- a/R/00-startApplication.R
+++ b/R/00-startApplication.R
@@ -1,19 +1,17 @@
 #' Start Application
 #'
 #' @param port port
-#' @param host host
 #' @param launch.browser If true, the system's default web browser will be launched
 #'
 #' @export
 startApplication <- function(
   port = getOption("shiny.port"),
-  host = "0.0.0.0",
   launch.browser = getOption("shiny.launch.browser", interactive())
 ) {
   shiny::runApp(
     system.file("app", package = "PEITHO"),
     port = port,
-    host = host,
+    host = "0.0.0.0",
     launch.browser = launch.browser
   )
 }

--- a/man/startApplication.Rd
+++ b/man/startApplication.Rd
@@ -6,14 +6,11 @@
 \usage{
 startApplication(
   port = getOption("shiny.port"),
-  host = "0.0.0.0",
   launch.browser = getOption("shiny.launch.browser", interactive())
 )
 }
 \arguments{
 \item{port}{port}
-
-\item{host}{host}
 
 \item{launch.browser}{If true, the system's default web browser will be launched}
 }


### PR DESCRIPTION
# PEITHO 26.02.1

## Bug Fixes

- Fixed missing argument `host` in `startApplication()` function, allowing specification of the host address when starting the Shiny app.