### PR TITLE
PEITHO 26.04.2: Fix/always return result list

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: PEITHO
 Type: Package
 Title: Workflow Management and Reproducible Analysis in R
-Version: 26.04.1
-Date: 2026-04-14
+Version: 26.04.2
+Date: 2026-04-20
 Authors@R: c(person("Antonia", "Runge", email = "antonia.runge@inwt-statistics.de", role = c("aut", "cre")))
 Description: PEITHO provides a flexible workflow management system for reproducible data analysis pipelines in R. Users can define, execute, export, and import multi-step workflows using configuration files or interactive tools. The package supports web text fetching, data processing, and integration with custom R scripts. Workflows and their results can be shared as zip bundles, enabling collaboration and reuse. Designed for both interactive and automated use, PEITHO helps streamline complex analysis tasks and ensures reproducibility.
 License: GPL (>= 3)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# PEITHO 26.04.2
+
+## Updates
+- Updated run.workflowstep() to always store output/error as lists
+- Extended test coverage to assert list-shaped output/error and list-shaped last_result
+
 # PEITHO 26.04.1
 
 ## Bug Fixes

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## Updates
 - Updated run.workflowstep() to always store output/error as lists
 - Extended test coverage to assert list-shaped output/error and list-shaped last_result
+- Added run_id to workflow run and state objects
 
 # PEITHO 26.04.1
 

--- a/R/01-default-functions.R
+++ b/R/01-default-functions.R
@@ -5,7 +5,7 @@
 # @param ... Additional arguments passed to `strsplit()`.
 # @return A character vector with the split elements.
 simple_split <- function(x, split, ...) {
-  strsplit(x, split, ...)[[1]]
+  as.list(strsplit(x, split, ...)[[1]])
 }
 
 #' Fetch and parse web text from a URL

--- a/R/01-default-functions.R
+++ b/R/01-default-functions.R
@@ -3,7 +3,7 @@
 # @param split A character string containing a regular expression to use
 #              as the split point.
 # @param ... Additional arguments passed to `strsplit()`.
-# @return A character vector with the split elements.
+# @return A list of character strings resulting from splitting `x` by `split`.
 simple_split <- function(x, split, ...) {
   as.list(strsplit(x, split, ...)[[1]])
 }

--- a/R/01-operationparam-class.R
+++ b/R/01-operationparam-class.R
@@ -122,6 +122,7 @@ extract_arg_list <- function(
   }
 
   if (operationparam$type == "result") {
+    # check that ref is present and non-empty
     ref <- operationparam$label
 
     if (is.null(ref) || !nzchar(ref)) {
@@ -145,6 +146,11 @@ extract_arg_list <- function(
       )
     }
 
+    # unwrap single-element lists to allow selecting from character vectors
+    if (is.list(arg_value) && length(arg_value) == 1L) {
+      arg_value <- arg_value[[1L]]
+    }
+
     selector <- operationparam$selector %||% NULL
     arg_value <- apply_result_selector(arg_value, selector)
 
@@ -162,7 +168,7 @@ extract_arg_list <- function(
       )
     }
 
-    # unwrap single-element lists
+    # unwrap single-element lists since we just converted to list above
     if (is.list(arg_value) && length(arg_value) == 1L) {
       arg_value <- arg_value[[1L]]
     }

--- a/R/01-workflow-class.R
+++ b/R/01-workflow-class.R
@@ -773,6 +773,8 @@ run.workflow <- function(
   # initialize state if not already a workflowstate
   if (!inherits(state, "workflowstate")) {
     state <- new_workflowstate(initial_input = state, run_id = run_id)
+  } else {
+    state$run_id <- run_id
   }
 
   validate_workflow(x, error_on_warn = TRUE)

--- a/R/01-workflow-class.R
+++ b/R/01-workflow-class.R
@@ -764,9 +764,15 @@ run.workflow <- function(
     )
   }
 
+  # create run_id
+  ts <- format(Sys.time(), "%Y%m%d%H%M%S", tz = "UTC")
+  rdm_suffix <- sprintf("%08x", sample.int(.Machine$integer.max, 1L))
+  run_id <- paste0(ts, "_", rdm_suffix)
+  PEITHO:::logInfo("Starting workflow run with ID: '%s'", run_id)
+
   # initialize state if not already a workflowstate
   if (!inherits(state, "workflowstate")) {
-    state <- new_workflowstate(initial_input = state)
+    state <- new_workflowstate(initial_input = state, run_id = run_id)
   }
 
   validate_workflow(x, error_on_warn = TRUE)
@@ -782,15 +788,11 @@ run.workflow <- function(
     )
   }
 
-  # create run_id
-  run_id <- format(Sys.time(), "%Y%m%d%H%M%S")
-
   # RUN workflow steps
   from <- max(1L, as.integer(from))
   to   <- min(length(x$steps), as.integer(to))
   idxs <- seq(from, to)
 
-  PEITHO:::logInfo("Starting workflow run with ID: '%s'", run_id)
   PEITHO:::logDebug("Running workflow from step %d to %d", from, to)
 
   for (j in seq_along(idxs)) {

--- a/R/01-workflow-class.R
+++ b/R/01-workflow-class.R
@@ -764,6 +764,7 @@ run.workflow <- function(
     )
   }
 
+  # initialize state if not already a workflowstate
   if (!inherits(state, "workflowstate")) {
     state <- new_workflowstate(initial_input = state)
   }
@@ -781,10 +782,15 @@ run.workflow <- function(
     )
   }
 
+  # create run_id
+  run_id <- format(Sys.time(), "%Y%m%d%H%M%S")
+
   # RUN workflow steps
   from <- max(1L, as.integer(from))
   to   <- min(length(x$steps), as.integer(to))
   idxs <- seq(from, to)
+
+  PEITHO:::logInfo("Starting workflow run with ID: '%s'", run_id)
   PEITHO:::logDebug("Running workflow from step %d to %d", from, to)
 
   for (j in seq_along(idxs)) {
@@ -830,7 +836,7 @@ run.workflow <- function(
     }
   }
 
-  new_workflowrun(x, state)
+  new_workflowrun(x, state, run_id = run_id)
 }
 
 

--- a/R/01-workflowrun-class.R
+++ b/R/01-workflowrun-class.R
@@ -1,9 +1,10 @@
 #' Workflow run object
-#' 
+#'
 #' This object represents a completed run of a workflow, containing the workflow definition
 #' and the final state after execution.
 #' @param workflow A `workflow` object.
 #' @param state A `workflowstate` object.
+#' @param run_id A unique identifier for the workflow run (optional).
 #' @return A `workflowrun` object.
 #' @export
 new_workflowrun <- function(workflow, state, run_id = NULL) {

--- a/R/01-workflowrun-class.R
+++ b/R/01-workflowrun-class.R
@@ -6,7 +6,7 @@
 #' @param state A `workflowstate` object.
 #' @return A `workflowrun` object.
 #' @export
-new_workflowrun <- function(workflow, state) {
+new_workflowrun <- function(workflow, state, run_id = NULL) {
   if (!inherits(workflow, "workflow")) {
     stop("Argument 'workflow' must be of class 'workflow'.")
   }
@@ -19,7 +19,8 @@ new_workflowrun <- function(workflow, state) {
       workflow = workflow,
       state    = state,
       errors   = state$errors,
-      last_result   = state$last_result
+      last_result   = state$last_result,
+      run_id   = run_id
     ),
     class = "workflowrun"
   )
@@ -37,6 +38,7 @@ print.workflowrun <- function(x, ...) {
   cat("Finished with state:\n")
   print(x$state)
   cat("  available fields: $", paste(names(x), collapse = ", $"), "\n", sep = "")
+  cat("  run ID:    ", x$run_id, "\n", sep = "")
   invisible(x)
 }
 

--- a/R/01-workflowstate-class.R
+++ b/R/01-workflowstate-class.R
@@ -5,16 +5,17 @@
 #' This object keeps track of the state while executing a workflow,
 #' including the initial input, the last result, and the list of executed step runs.
 #' @param initial_input The initial input provided to the workflow.
+#' @param run_id A unique identifier for the workflow run (optional).
 #' @return A `workflowstate` object.
 #' @export
-new_workflowstate <- function(initial_input = NULL) {
+new_workflowstate <- function(initial_input = NULL, run_id = NULL) {
   structure(
     list(
       initial_input = initial_input,
       errors        = NULL,            # all errors encountered
       last_result   = initial_input,   # last step’s result
       stepruns      = list(),           # list of workflowsteprun objects
-
+      run_id        = run_id,           # unique identifier for the workflow run
       # caches (duplication on purpose, we may later decide if we use 'id' or 'name' at the end)
       results_by_id   = list(),
       results_by_name = list(),

--- a/R/01-workflowstate-class.R
+++ b/R/01-workflowstate-class.R
@@ -76,7 +76,7 @@ print.workflowstate <- function(x, ...) {
     cat("  error in steps:", paste(which(is_error), collapse = ", "), "\n", sep = " ")
     cat("                 (use summary() to see error details)\n")
     first_error <- x$stepruns[[which(is_error)[1]]]$error
-    if (is.list(first_error)) {
+    if (is.list(first_error) && !inherits(first_error, "condition")) {
       non_null <- Filter(function(e) !is.null(e), first_error)
       first_error <- if (length(non_null) > 0L) non_null[[1L]] else NULL
     }

--- a/R/01-workflowstate-class.R
+++ b/R/01-workflowstate-class.R
@@ -75,7 +75,12 @@ print.workflowstate <- function(x, ...) {
   if (any(is_error)) {
     cat("  error in steps:", paste(which(is_error), collapse = ", "), "\n", sep = " ")
     cat("                 (use summary() to see error details)\n")
-    cat("  first error:   ", trunc(x$stepruns[[which(is_error)[1]]]$error), "\n", sep = "")
+    first_error <- x$stepruns[[which(is_error)[1]]]$error
+    if (is.list(first_error)) {
+      non_null <- Filter(function(e) !is.null(e), first_error)
+      first_error <- if (length(non_null) > 0L) non_null[[1L]] else NULL
+    }
+    cat("  first error:   ", trunc(first_error), "\n", sep = "")
   }
   cat("  initial_input: ", trunc(x$initial_input), "\n", sep = "")
   cat("  last_result:   ", trunc(x$last_result), "\n", sep = "")

--- a/R/01-workflowstate-class.R
+++ b/R/01-workflowstate-class.R
@@ -46,6 +46,12 @@ truncate_many <- function(vals, n_char, n_items, collapse = ", \n") {
 trunc <- function(val, n_char = 40, n_items = 5) {
   if (is.null(val)) return("NULL")
 
+  # unwrap single-element lists
+  # (we often have lists of length 1 due to how we store outputs and errors)
+  if (is.list(val) && length(val) == 1L) {
+    val <- val[[1L]]
+  }
+
   # lists of characters
   if (is.list(val) && all(vapply(val, is.character, logical(1)))) {
     return(truncate_many(unlist(val), n_char = n_char, n_items = n_items))

--- a/R/01-workflowstep-class.R
+++ b/R/01-workflowstep-class.R
@@ -418,8 +418,8 @@ run.workflowstep <- function(
     steprun <- new_workflowsteprun(
       step   = x,
       args   = args,
-      output = run$output,
-      error  = run$error
+      output = list(run$output),   # always a list
+      error  = list(run$error)     # always a list
     )
   }
 

--- a/R/01-workflowstep-class.R
+++ b/R/01-workflowstep-class.R
@@ -418,8 +418,8 @@ run.workflowstep <- function(
     steprun <- new_workflowsteprun(
       step   = x,
       args   = args,
-      output = list(run$output),   # always a list
-      error  = list(run$error)     # always a list
+      output = if (length(run$output) > 0L) as.list(run$output) else list(run$output),
+      error  = list(run$error)
     )
   }
 

--- a/R/01-workflowstep-class.R
+++ b/R/01-workflowstep-class.R
@@ -416,6 +416,7 @@ run.workflowstep <- function(
       if (is_single_result) "" else "s"
     )
 
+    # return list of results/errors (to keep structure consistent)
     steprun <- new_workflowsteprun(
       step   = x,
       args   = args,

--- a/R/01-workflowstep-class.R
+++ b/R/01-workflowstep-class.R
@@ -418,7 +418,7 @@ run.workflowstep <- function(
     steprun <- new_workflowsteprun(
       step   = x,
       args   = args,
-      output = if (length(run$output) > 0L) as.list(run$output) else list(run$output),
+      output = if (is.null(run$output)) list(NULL) else as.list(run$output),
       error  = list(run$error)
     )
   }

--- a/R/01-workflowstep-class.R
+++ b/R/01-workflowstep-class.R
@@ -418,7 +418,7 @@ run.workflowstep <- function(
     steprun <- new_workflowsteprun(
       step   = x,
       args   = args,
-      output = if (is.null(run$output)) list(NULL) else as.list(run$output),
+      output = list(run$output),
       error  = list(run$error)
     )
   }

--- a/R/01-workflowstep-class.R
+++ b/R/01-workflowstep-class.R
@@ -399,7 +399,8 @@ run.workflowstep <- function(
       step   = x,
       args   = args,
       output = results,
-      error  = errors
+      error  = errors,
+      run_id = state$run_id
     )
   } else {
     PEITHO:::logDebug("  Running command: NO LOOPING")
@@ -419,7 +420,8 @@ run.workflowstep <- function(
       step   = x,
       args   = args,
       output = list(run$output),
-      error  = list(run$error)
+      error  = list(run$error),
+      run_id = state$run_id
     )
   }
 

--- a/R/01-workflowsteprun-class.R
+++ b/R/01-workflowsteprun-class.R
@@ -27,11 +27,7 @@ new_workflowsteprun <- function(step, args, output = NULL, error = NULL, ...) {
       args   = args,   # actual arguments passed to the function
       output = output, # result (if no error)
       error  = error,  # condition object (if any)
-      has_error = if (is.list(error)) {
-        any(!sapply(error, is.null))
-      } else {
-        !is.null(error)
-      },
+      has_error = any(!sapply(error, is.null)), # logical flag for convenience
       meta   = list(...)
     ),
     class = c("workflowsteprun", "list")

--- a/R/01-workflowsteprun-class.R
+++ b/R/01-workflowsteprun-class.R
@@ -10,10 +10,11 @@
 #'  Contains actual values used during execution (e.g. results of previous steps).
 #' @param output The output produced by the step, if successful.
 #' @param error  An error object if the step failed, otherwise `NULL`.
+#' @param run_id A unique identifier for the workflow run this step belongs to.
 #' @param ...    Additional metadata to store with the step run.
 #' @return A `workflowsteprun` object.
 #' @export
-new_workflowsteprun <- function(step, args, output = NULL, error = NULL, ...) {
+new_workflowsteprun <- function(step, args, output = NULL, error = NULL, run_id = NULL, ...) {
   # validate that step is a workflowstep
   if (!inherits(step, "workflowstep")) {
     stop("Argument 'step' must be of class 'workflowstep'.")
@@ -27,6 +28,7 @@ new_workflowsteprun <- function(step, args, output = NULL, error = NULL, ...) {
       args   = args,   # actual arguments passed to the function
       output = output, # result (if no error)
       error  = error,  # condition object (if any)
+      run_id = run_id, # workflow run identifier
       has_error = any(!sapply(error, is.null)), # logical flag for convenience
       meta   = list(...)
     ),
@@ -41,6 +43,9 @@ new_workflowsteprun <- function(step, args, output = NULL, error = NULL, ...) {
 #' @export
 print.workflowsteprun <- function(x, ...) {
   cat("<workflowsteprun>\n")
+  if (!is.null(x$run_id) && nzchar(x$run_id)) {
+    cat("  run id:    ", x$run_id, "\n", sep = "")
+  }
   cat("  step id:   ", x$step$entry, "  (", x$step$name, ")\n", sep = "")
   cat("  command: ", x$step$command, "\n", sep = "")
   cat("  args:      ", paste(names(x$args), collapse = ", "), "\n", sep = "")
@@ -108,6 +113,7 @@ summary.workflowsteprun <- function(object, ...) {
   }
 
   list(
+    run_id = object$run_id,
     entry  = object$step$entry,
     name   = object$step$name,
     label  = object$step$label,

--- a/R/01-workflowsteprun-class.R
+++ b/R/01-workflowsteprun-class.R
@@ -8,8 +8,10 @@
 #' @param step   A `workflowstep` object representing the step definition.
 #' @param args   A list of arguments that were passed to the step's command.
 #'  Contains actual values used during execution (e.g. results of previous steps).
-#' @param output The output produced by the step, if successful.
-#' @param error  An error object if the step failed, otherwise `NULL`.
+#' @param output List of outputs produced by the step if it executed
+#'               successfully, otherwise list(NULL).
+#' @param error  List of error conditions if the step encountered errors,
+#'               otherwise list(NULL).
 #' @param run_id A unique identifier for the workflow run this step belongs to.
 #' @param ...    Additional metadata to store with the step run.
 #' @return A `workflowsteprun` object.

--- a/man/new_workflowrun.Rd
+++ b/man/new_workflowrun.Rd
@@ -4,12 +4,14 @@
 \alias{new_workflowrun}
 \title{Workflow run object}
 \usage{
-new_workflowrun(workflow, state)
+new_workflowrun(workflow, state, run_id = NULL)
 }
 \arguments{
 \item{workflow}{A `workflow` object.}
 
 \item{state}{A `workflowstate` object.}
+
+\item{run_id}{A unique identifier for the workflow run (optional).}
 }
 \value{
 A `workflowrun` object.

--- a/man/new_workflowstate.Rd
+++ b/man/new_workflowstate.Rd
@@ -4,10 +4,12 @@
 \alias{new_workflowstate}
 \title{Create a new workflow state object}
 \usage{
-new_workflowstate(initial_input = NULL)
+new_workflowstate(initial_input = NULL, run_id = NULL)
 }
 \arguments{
 \item{initial_input}{The initial input provided to the workflow.}
+
+\item{run_id}{A unique identifier for the workflow run (optional).}
 }
 \value{
 A `workflowstate` object.

--- a/man/new_workflowsteprun.Rd
+++ b/man/new_workflowsteprun.Rd
@@ -4,7 +4,14 @@
 \alias{new_workflowsteprun}
 \title{Create a new workflow step run object}
 \usage{
-new_workflowsteprun(step, args, output = NULL, error = NULL, ...)
+new_workflowsteprun(
+  step,
+  args,
+  output = NULL,
+  error = NULL,
+  run_id = NULL,
+  ...
+)
 }
 \arguments{
 \item{step}{A `workflowstep` object representing the step definition.}
@@ -15,6 +22,8 @@ Contains actual values used during execution (e.g. results of previous steps).}
 \item{output}{The output produced by the step, if successful.}
 
 \item{error}{An error object if the step failed, otherwise `NULL`.}
+
+\item{run_id}{A unique identifier for the workflow run this step belongs to.}
 
 \item{...}{Additional metadata to store with the step run.}
 }

--- a/man/new_workflowsteprun.Rd
+++ b/man/new_workflowsteprun.Rd
@@ -19,9 +19,11 @@ new_workflowsteprun(
 \item{args}{A list of arguments that were passed to the step's command.
 Contains actual values used during execution (e.g. results of previous steps).}
 
-\item{output}{The output produced by the step, if successful.}
+\item{output}{List of outputs produced by the step if it executed
+successfully, otherwise list(NULL).}
 
-\item{error}{An error object if the step failed, otherwise `NULL`.}
+\item{error}{List of error conditions if the step encountered errors,
+otherwise list(NULL).}
 
 \item{run_id}{A unique identifier for the workflow run this step belongs to.}
 

--- a/tests/testthat/test-example-workflow.R
+++ b/tests/testthat/test-example-workflow.R
@@ -20,7 +20,8 @@ test_that("workflow can be exported, imported, and run as in example_wf.R", {
 
   # Run workflow (steps 1 to 4)
   my_run_1 <- PEITHO::run(my_wf, from = 1, to = 4)
-  expect_type(my_run_1$state$last_result, "character")
+  expect_type(my_run_1$state$last_result, "list")
+  expect_type(my_run_1$state$last_result[[1]], "character")
   expect_length(my_run_1$state$last_result, 1)
 
   # Truncate output

--- a/tests/testthat/test-run-workflow.R
+++ b/tests/testthat/test-run-workflow.R
@@ -32,8 +32,8 @@ test_that("run.workflow executes all steps and returns results", {
   expect_s3_class(result$workflow, "workflow")
   expect_s3_class(result$state, "workflowstate")
   expect_length(result$state$stepruns, 2)
-  expect_equal(result$state$stepruns[[1]]$output, list(c("hallo", "test")))
-  expect_equal(result$state$stepruns[[2]]$output, list(c("foo", "bar")))
+  expect_equal(result$state$stepruns[[1]]$output, list(list(c("hallo", "test"))))
+  expect_equal(result$state$stepruns[[2]]$output, list(list(c("foo", "bar"))))
 })
 
 # Test workflow with error in step

--- a/tests/testthat/test-run-workflowstep.R
+++ b/tests/testthat/test-run-workflowstep.R
@@ -81,7 +81,7 @@ test_that("make_param_from_arg stores result selector separately", {
   expect_equal(param$selector, "c(1,3)")
 })
 
-test_that("run.workflowstep without looping returns single output and NULL error", {
+test_that("run.workflowstep without looping returns lists with single output and NULL error", {
   step <- new_workflowstep(
     entry   = 1,
     command = "toupper",
@@ -92,8 +92,9 @@ test_that("run.workflowstep without looping returns single output and NULL error
   steprun <- run.workflowstep(step, state, env = globalenv())
 
   expect_s3_class(steprun, "workflowsteprun")
-  expect_equal(steprun$output, "HELLO")
-  expect_null(steprun$error)
+  expect_equal(steprun$output, list("HELLO"))
+  expect_equal(length(steprun$error), 1L)
+  expect_true(all(sapply(steprun$error, is.null)))
   expect_false(steprun$has_error)
 })
 

--- a/tests/testthat/test-run-workflowstep.R
+++ b/tests/testthat/test-run-workflowstep.R
@@ -81,6 +81,41 @@ test_that("make_param_from_arg stores result selector separately", {
   expect_equal(param$selector, "c(1,3)")
 })
 
+test_that("run.workflowstep without looping returns single output and NULL error", {
+  step <- new_workflowstep(
+    entry   = 1,
+    command = "toupper",
+    args    = "x = \"hello\"",
+    loop    = "no"
+  )
+  state <- new_workflowstate()
+  steprun <- run.workflowstep(step, state, env = globalenv())
+
+  expect_s3_class(steprun, "workflowsteprun")
+  expect_equal(steprun$output, "HELLO")
+  expect_null(steprun$error)
+  expect_false(steprun$has_error)
+})
+
+test_that("run.workflowstep with looping iterates over list arg and returns list of outputs", {
+  step <- new_workflowstep(
+    entry   = 2,
+    command = "toupper",
+    args    = "x = @#*L*#@step 1@#*L*#@",
+    loop    = "auto"
+  )
+  state <- new_workflowstate()
+  state$results_by_name[["step_1"]] <- c("hello", "world", "foo")
+
+  steprun <- run.workflowstep(step, state, step_i = 2, env = globalenv())
+
+  expect_s3_class(steprun, "workflowsteprun")
+  expect_equal(steprun$output, list("HELLO", "WORLD", "FOO"))
+  expect_equal(length(steprun$error), 3L)
+  expect_true(all(sapply(steprun$error, is.null)))
+  expect_false(steprun$has_error)
+})
+
 test_that("extract_arg_list applies selector to previous result", {
   state <- new_workflowstate()
   state$results_by_name[["step_1"]] <- c("a", "b", "c")

--- a/tests/testthat/test-run-workflowstep.R
+++ b/tests/testthat/test-run-workflowstep.R
@@ -45,7 +45,7 @@ test_that("run.workflowstep executes command and returns correct output", {
   state <- new_workflowstate()
   steprun <- run.workflowstep(step, state, path_to_folder = tempdir())
   expect_s3_class(steprun, "workflowsteprun")
-  expect_equal(steprun$output, list(c("hallo", "test")))
+  expect_equal(steprun$output, list(list(c("hallo", "test"))))
   expect_equal(steprun$error, list(NULL))
 })
 

--- a/tests/testthat/test-run-workflowstep.R
+++ b/tests/testthat/test-run-workflowstep.R
@@ -46,7 +46,7 @@ test_that("run.workflowstep executes command and returns correct output", {
   steprun <- run.workflowstep(step, state, path_to_folder = tempdir())
   expect_s3_class(steprun, "workflowsteprun")
   expect_equal(steprun$output, list(c("hallo", "test")))
-  expect_null(steprun$error)
+  expect_equal(steprun$error, list(NULL))
 })
 
 test_that("run.workflowstep handles command error", {
@@ -61,8 +61,8 @@ test_that("run.workflowstep handles command error", {
   state <- new_workflowstate()
   steprun <- run.workflowstep(step, state, path_to_folder = tempdir())
   expect_s3_class(steprun, "workflowsteprun")
-  expect_null(steprun$output)
-  expect_true(inherits(steprun$error, "error"))
+  expect_equal(steprun$output, list(NULL))
+  expect_true(inherits(steprun$error[[1]], "error"))
   rm(error_fn, envir = .GlobalEnv)
 })
 

--- a/tests/testthat/test-vignette-peitho_workflow_basics.R
+++ b/tests/testthat/test-vignette-peitho_workflow_basics.R
@@ -19,7 +19,7 @@ test_that("save_as_zip exports workflow to zip", {
 # Test: Running a Workflow
 test_that("run executes workflow steps", {
   wf <- new_workflow(workflow_file_paths = workflow_file_paths(path = ""))
-  run_result <- run(wf, from = 1, to = 5)
+  run_result <- run(wf, from = 1, to = length(wf$steps))
   expect_true(!is.null(run_result$state$last_result))
   expect_true(length(run_result$state$last_result) >= 0)
 })


### PR DESCRIPTION
# PEITHO 26.04.2

## Updates
- Updated run.workflowstep() to always store output/error as lists
- Extended test coverage to assert list-shaped output/error and list-shaped last_result
- Added run_id to workflow run and state objects