### PR TITLE
PEITHO 26.05.1: reset custom functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: PEITHO
 Type: Package
 Title: Workflow Management and Reproducible Analysis in R
-Version: 26.05.0
+Version: 26.05.1
 Date: 2026-05-11
 Authors@R: c(person("Antonia", "Runge", email = "antonia.runge@inwt-statistics.de", role = c("aut", "cre")))
 Description: PEITHO provides a flexible workflow management system for reproducible data analysis pipelines in R. Users can define, execute, export, and import multi-step workflows using configuration files or interactive tools. The package supports web text fetching, data processing, and integration with custom R scripts. Workflows and their results can be shared as zip bundles, enabling collaboration and reuse. Designed for both interactive and automated use, PEITHO helps streamline complex analysis tasks and ensures reproducibility.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# PEITHO 26.05.1
+
+## Updates
+- Updated the “Folders & Files” module to make it easier to manage custom workflow functions by adding one-click actions to copy defaults into the workflow or reset the workflow functions back to defaults.
+
 # PEITHO 26.05.0
 
 ## New Features

--- a/R/02-workflow_files-module.R
+++ b/R/02-workflow_files-module.R
@@ -12,19 +12,61 @@ workflow_files_ui <- function(id, title = "") {
     fluidRow(
       column(
         width = 4,
-        tags$p(
-          "Inspect package defaults and available namespace functions.",
-          class = "text-muted"
+        div(
+          class = "well well-sm",
+          tags$h4(icon("book"), "PEITHO defaults"),
+          tags$p(
+            "Inspect package defaults and copy them into workflow for customization.",
+            class = "text-muted"
+          ),
+          actionButton(
+            ns("show_defaults"),
+            "Show",
+            icon = icon("book"),
+            width = "100%"
+          ),
+          tags$hr(),
+          actionButton(
+            ns("copy_defaults"),
+            "Copy",
+            icon = icon("copy"),
+            class = "btn-danger btn-block"
+          ),
+          tags$p(
+            "Overwrites custom functions in the workflow.",
+            class = "text-danger small"
+          ),
+          actionButton(
+            ns("reset_defaults"),
+            "Reset workflow functions",
+            icon = icon("undo"),
+            class = "btn-danger btn-block"
+          ),
+          tags$p(
+            "Deletes custom functions and reverts to package defaults.",
+            class = "text-danger small"
+          )
         ),
-        actionButton(ns("show_defaults"), "Show package functions", icon = icon("book")),
-        actionButton(ns("browse_functions"), "Browse available functions", icon = icon("list")),
-        tags$hr(),
-        tags$p(
-          "Browse workflow files.",
-          class = "text-muted"
+
+        div(
+          class = "well well-sm",
+          tags$h4(icon("list"), "All available functions"),
+          tags$p(
+            "Browse all functions available in the current session, including custom workflow functions.",
+            class = "text-muted"
+          ),
+          actionButton(ns("browse_functions"), "Browse functions",
+                       icon = icon("list"),
+                       class = "btn-default btn-block")
         ),
-        htmlOutput(ns("wf_dir")),
-        shinyTree::shinyTree(ns("file_tree"), search = FALSE, theme = "proton")
+
+        div(
+          class = "well well-sm",
+          tags$h4(icon("folder-open"), "Workflow files"),
+          tags$p("Browse files in the current workflow.", class = "text-muted"),
+          htmlOutput(ns("wf_dir")),
+          shinyTree::shinyTree(ns("file_tree"), search = FALSE, theme = "proton")
+        )
       ),
       column(
         width = 8,

--- a/R/02-workflow_files-module.R
+++ b/R/02-workflow_files-module.R
@@ -293,7 +293,7 @@ workflow_files_server <- function(id, active_dir) {
       dir_path <- active_dir()
 
       if (!is.null(dir_path) && dir.exists(dir_path)) {
-        functions_path <- PEITHO:::workflow_file_paths(path = dir_path)$functions_path
+        functions_path <- get_functions_path(dir_path)
 
         if (file_nonempty(functions_path)) {
           extra_env <- tryCatch(

--- a/R/02-workflow_files-module.R
+++ b/R/02-workflow_files-module.R
@@ -43,7 +43,7 @@ workflow_files_ui <- function(id, title = "") {
             class = "btn-danger btn-block"
           ),
           tags$p(
-            "Deletes custom functions and reverts to package defaults.",
+            "Removes custom function definitions from the workflow and reverts to package defaults.",
             class = "text-danger small"
           )
         ),

--- a/R/02-workflow_files-module.R
+++ b/R/02-workflow_files-module.R
@@ -369,5 +369,68 @@ workflow_files_server <- function(id, active_dir) {
         status_msg(paste("Could not save file:", conditionMessage(e)))
       })
     })
+
+    observeEvent(input$copy_defaults, {
+      req(active_dir(), dir.exists(active_dir()))
+
+      defaults_text <- tryCatch(
+        PEITHO:::default_workflow_functions_text(),
+        error = function(e) {
+          status_msg(paste("Could not load package defaults:", conditionMessage(e)))
+          NULL
+        }
+      )
+      req(!is.null(defaults_text))
+
+      functions_path <- PEITHO:::workflow_file_paths(path = active_dir())$functions_path
+      req(!is.null(functions_path))
+
+      lines <- strsplit(defaults_text, "\n", fixed = TRUE)[[1]]
+
+      tryCatch({
+        con <- file(functions_path, open = "w", encoding = "UTF-8")
+        on.exit(close(con), add = TRUE)
+        writeLines(lines, con = con)
+
+        selected_file(functions_path)
+        selected_label(NULL)
+        updateTextAreaInput(session, "file_editor", value = defaults_text)
+
+        if (is_running_online()) {
+          status_msg(sprintf(
+            "Saved %s. Warning: Running online; skipping loading %s into the environment!",
+            basename(functions_path),
+            basename(functions_path)
+          ))
+        } else {
+          status_msg(sprintf(
+            "Saved %s. Updated custom functions will be reloaded on the next workflow run.",
+            basename(functions_path)
+          ))
+        }
+      }, error = function(e) {
+        status_msg(paste("Could not copy defaults:", conditionMessage(e)))
+      })
+    })
+
+    observeEvent(input$reset_defaults, {
+      req(active_dir(), dir.exists(active_dir()))
+
+      functions_path <- PEITHO:::workflow_file_paths(path = active_dir())$functions_path
+      req(!is.null(functions_path))
+
+      tryCatch({
+        con <- file(functions_path, open = "w", encoding = "UTF-8")
+        on.exit(close(con), add = TRUE)
+        writeLines(character(0), con = con)
+
+        selected_file(functions_path)
+        selected_label(NULL)
+        updateTextAreaInput(session, "file_editor", value = "")
+        status_msg("Cleared functions.R. Workflow will use package defaults on next run.")
+      }, error = function(e) {
+        status_msg(paste("Could not clear functions.R:", conditionMessage(e)))
+      })
+    })
   })
 }

--- a/R/02-workflow_files-module.R
+++ b/R/02-workflow_files-module.R
@@ -43,7 +43,7 @@ workflow_files_ui <- function(id, title = "") {
             class = "btn-danger btn-block"
           ),
           tags$p(
-            "Removes custom function definitions from the workflow and reverts to package defaults.",
+            "Removes custom functions from the workflow and reverts to package defaults.",
             class = "text-danger small"
           )
         ),

--- a/R/02-workflow_files-module.R
+++ b/R/02-workflow_files-module.R
@@ -174,6 +174,45 @@ workflow_files_server <- function(id, active_dir) {
         file.access(path, 2) == 0
     }
 
+    get_functions_path <- function(dir_path = active_dir()) {
+      if (is.null(dir_path) || !dir.exists(dir_path)) return(NULL)
+      PEITHO:::workflow_file_paths(path = dir_path)$functions_path
+    }
+
+    write_text_file_utf8 <- function(path, value) {
+      if (is.null(value)) value <- ""
+      lines <- if (identical(value, "")) character(0) else strsplit(value, "\n", fixed = TRUE)[[1]]
+
+      con <- file(path, open = "w", encoding = "UTF-8")
+      on.exit(close(con), add = TRUE)
+      writeLines(lines, con = con)
+    }
+
+    is_functions_file <- function(path) {
+      functions_path <- get_functions_path(dirname(path))
+      if (is.null(functions_path)) return(FALSE)
+
+      identical(
+        normalizePath(path, winslash = "/", mustWork = TRUE),
+        normalizePath(functions_path, winslash = "/", mustWork = FALSE)
+      )
+    }
+
+    set_functions_saved_status <- function(path) {
+      if (is_running_online()) {
+        status_msg(sprintf(
+          "Saved %s. Warning: Running online; skipping loading %s into the environment!",
+          basename(path),
+          basename(path)
+        ))
+      } else {
+        status_msg(sprintf(
+          "Saved %s. Updated custom functions will be reloaded on the next workflow run.",
+          basename(path)
+        ))
+      }
+    }
+
     output$wf_dir <- renderUI({
       dir_path <- active_dir()
       if (is.null(dir_path) || !dir.exists(dir_path)) {
@@ -335,33 +374,12 @@ workflow_files_server <- function(id, active_dir) {
       req(file.exists(path), !dir.exists(path))
 
       value <- input$file_editor
-      if (is.null(value)) value <- ""
-      lines <- strsplit(value, "\n", fixed = TRUE)[[1]]
 
       tryCatch({
-        con <- file(path, open = "w", encoding = "UTF-8")
-        on.exit(close(con), add = TRUE)
-        writeLines(lines, con = con)
+        write_text_file_utf8(path, value)
 
-        functions_path <- PEITHO:::workflow_file_paths(path = dirname(path))$functions_path
-        is_functions_file <- identical(
-          normalizePath(path, winslash = "/", mustWork = TRUE),
-          normalizePath(functions_path, winslash = "/", mustWork = FALSE)
-        )
-
-        if (is_functions_file) {
-          if (is_running_online()) {
-            status_msg(sprintf(
-              "Saved %s. Warning: Running online; skipping loading %s into the environment!",
-              basename(path),
-              basename(path)
-            ))
-          } else {
-            status_msg(sprintf(
-              "Saved %s. Updated custom functions will be reloaded on the next workflow run.",
-              basename(path)
-            ))
-          }
+        if (is_functions_file(path)) {
+          set_functions_saved_status(path)
         } else {
           status_msg(sprintf("Saved %s", basename(path)))
         }
@@ -382,32 +400,16 @@ workflow_files_server <- function(id, active_dir) {
       )
       req(!is.null(defaults_text))
 
-      functions_path <- PEITHO:::workflow_file_paths(path = active_dir())$functions_path
+      functions_path <- get_functions_path()
       req(!is.null(functions_path))
 
-      lines <- strsplit(defaults_text, "\n", fixed = TRUE)[[1]]
-
       tryCatch({
-        con <- file(functions_path, open = "w", encoding = "UTF-8")
-        on.exit(close(con), add = TRUE)
-        writeLines(lines, con = con)
+        write_text_file_utf8(functions_path, defaults_text)
 
         selected_file(functions_path)
         selected_label(NULL)
         updateTextAreaInput(session, "file_editor", value = defaults_text)
-
-        if (is_running_online()) {
-          status_msg(sprintf(
-            "Saved %s. Warning: Running online; skipping loading %s into the environment!",
-            basename(functions_path),
-            basename(functions_path)
-          ))
-        } else {
-          status_msg(sprintf(
-            "Saved %s. Updated custom functions will be reloaded on the next workflow run.",
-            basename(functions_path)
-          ))
-        }
+        set_functions_saved_status(functions_path)
       }, error = function(e) {
         status_msg(paste("Could not copy defaults:", conditionMessage(e)))
       })
@@ -416,13 +418,11 @@ workflow_files_server <- function(id, active_dir) {
     observeEvent(input$reset_defaults, {
       req(active_dir(), dir.exists(active_dir()))
 
-      functions_path <- PEITHO:::workflow_file_paths(path = active_dir())$functions_path
+      functions_path <- get_functions_path()
       req(!is.null(functions_path))
 
       tryCatch({
-        con <- file(functions_path, open = "w", encoding = "UTF-8")
-        on.exit(close(con), add = TRUE)
-        writeLines(character(0), con = con)
+        write_text_file_utf8(functions_path, "")
 
         selected_file(functions_path)
         selected_label(NULL)


### PR DESCRIPTION
# PEITHO 26.05.1

## Updates
- Updated the “Folders & Files” module to make it easier to manage custom workflow functions by adding one-click actions to copy defaults into the workflow or reset the workflow functions back to defaults.